### PR TITLE
Add Canadian Dollar (CAD) exchange rate

### DIFF
--- a/app/src/main/java/com/samourai/sentinel/util/ExchangeRateFactory.java
+++ b/app/src/main/java/com/samourai/sentinel/util/ExchangeRateFactory.java
@@ -25,7 +25,7 @@ public class ExchangeRateFactory	{
     private static ExchangeRateFactory instance = null;
 
     private static String[] currencies = {
-            "CNY", "EUR", "GBP", "RUB", "USD"
+            "CNY", "EUR", "GBP", "RUB", "USD", "CAD"
     };
 
     private static String[] currencyLabels = {
@@ -33,7 +33,8 @@ public class ExchangeRateFactory	{
             "Euro - EUR",
             "British Pound Sterling - GBP",
             "Chinese Yuan - CNY",
-            "Russian Rouble - RUB"
+            "Russian Rouble - RUB",
+            "Canadian Dollars - CAD",
     };
 
     private static String[] currencyLabelsBTCe = {


### PR DESCRIPTION
Add CAD as one of the exchange rate options.

The data is already available from LocalBitcoins, it just needs to be selectable in the options.